### PR TITLE
Use PVC access mode with ReadWriteOnce

### DIFF
--- a/charts/safe-config/Chart.yaml
+++ b/charts/safe-config/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: safe-config
-version: 0.1.6
+version: 0.1.7
 appVersion: v2.59.0
 description: A Helm chart for configuration service
 type: application

--- a/charts/safe-config/values.yaml
+++ b/charts/safe-config/values.yaml
@@ -65,7 +65,6 @@ persistence:
   ##
   accessModes:
     - ReadWriteOnce
-    - ReadWriteMany
 
   ## @param persistence.size Volume size
   ##

--- a/charts/safe-transaction/Chart.yaml
+++ b/charts/safe-transaction/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: safe-transaction
-version: 0.1.12
+version: 0.1.13
 appVersion: v4.22.4
 description: A Helm chart for transaction service
 type: application

--- a/charts/safe-transaction/values.yaml
+++ b/charts/safe-transaction/values.yaml
@@ -101,7 +101,6 @@ persistence:
   ##
   accessModes:
     - ReadWriteOnce
-    - ReadWriteMany
 
   ## @param persistence.size Volume size
   ##


### PR DESCRIPTION
Use ReadWriteOnce as default accessMode for PVC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Version Updates**
  - Updated `safe-config` chart to version 0.1.7.
  - Updated `safe-transaction` chart to version 0.1.13.

- **Configuration Changes**
  - Modified persistence settings to remove `ReadWriteMany` access mode, retaining `ReadWriteOnce` for both `safe-config` and `safe-transaction` configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->